### PR TITLE
Fix: User's name was an empty string when registrering manually

### DIFF
--- a/packages/backend/api/src/services/middleware.ts
+++ b/packages/backend/api/src/services/middleware.ts
@@ -30,7 +30,7 @@ export const isAuthorized: RequestHandler = async (req, res, next) => {
     // Get the user ID from the memory cache or the database
     const user_id = await getUserId(
       payload.sub as string,
-      payload.name as string,
+      (payload.name ?? payload.email.split("@")[0]) as string,
       payload.email as string
     );
 


### PR DESCRIPTION
When registering an account without logging in through Google OAuth with Clerk, the registrant's name would be an empty string and then not stored in the database. Now the name is what comes before '@' in their provided email address.